### PR TITLE
Lazy open files with cache

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -79,6 +79,8 @@ setup(
         "pytest==6.0.1",
         "pybenzinaparse @ git+https://github.com/satyaog/pybenzinaparse.git@653e71586726ed04293d7362e3539e26dc28850c#egg=pybenzinaparse-0.2.1",
     ],
+    extras_require={"psnrhma": ["opencv-python",
+                                "scipy"]},
     packages             = find_packages("src"),
     package_dir          = {'': 'src'},
     ext_modules          = [

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -77,7 +77,7 @@ setup(
         "meson>=0.54.0",
         "numpy>=1.10",
         "pytest==6.0.1",
-        "pybenzinaparse @ git+https://github.com/satyaog/pybenzinaparse.git@653e71586726ed04293d7362e3539e26dc28850c#egg=pybenzinaparse-0.2.1",
+        "pybenzinaparse @ git+https://github.com/satyaog/pybenzinaparse.git@0.2.2#egg=pybenzinaparse-0.2.2",
     ],
     extras_require={"psnrhma": ["opencv-python",
                                 "scipy"]},

--- a/src/benzina/torch/dataloader.py
+++ b/src/benzina/torch/dataloader.py
@@ -9,8 +9,6 @@ from   torch.utils.data.dataloader import default_collate
 from   contextlib                  import suppress
 from   .                           import operations as ops
 
-from   benzina.utils.file import Track
-
 
 class DataLoader(torch.utils.data.DataLoader):
     """
@@ -258,8 +256,7 @@ class _DataLoaderIter:
         indices     = [int(i)                     for i in indices]
         ptrs        = [int(buffer[n].data_ptr())  for n in range(len(indices))]
         samples     = [self.dataset[i]            for i in indices]
-        items, auxd = zip(*[(Track(item.input.as_file(), item.input_label), item.aux)
-                            for item in samples])
+        items, auxd = zip(*[(sample.input, sample.aux) for sample in samples])
         token       = (buffer, self.collate_fn(auxd))
         t_args      = (self.shape, self.RNG)
 

--- a/src/benzina/torch/dataset.py
+++ b/src/benzina/torch/dataset.py
@@ -51,8 +51,12 @@ class Dataset(torch.utils.data.Dataset):
                              "not specified.")
 
         self._track = track
-        self._track.open()
-        self._filename = track.file.path
+        if self._track.file.closed:
+            # Parse metadata then re-close the file handle
+            self._track.open()
+            self._track.close()
+
+        self._filename = track.file.name
 
     @property
     def filename(self):
@@ -81,20 +85,18 @@ class ClassificationDataset(Dataset):
             track. (default: ``"bzna_thumb"``)
     """
 
-    _Item = namedtuple("Item", ["input", "input_label", "target"])
+    _Item = namedtuple("Item", ["input", "input_label", "aux"])
 
     def __init__(self,
                  archive: typing.Union[str, _TrackPairType] = None,
                  tracks: _ClassTracksType = ("bzna_input", "bzna_target"),
                  input_label: str = "bzna_thumb"):
         try:
-            archive, tracks, input_label = \
-                ClassificationDataset._validate_args(
-                    None, archive, input_label)
+            archive, tracks = \
+                ClassificationDataset._validate_source(None, archive)
         except (TypeError, ValueError):
-            archive, tracks, input_label = \
-                ClassificationDataset._validate_args(
-                    archive, tracks, input_label)
+            archive, tracks = \
+                ClassificationDataset._validate_source(archive, tracks)
 
         if archive is not None:
             input_track = Track(archive, tracks[0])
@@ -105,22 +107,31 @@ class ClassificationDataset(Dataset):
 
         Dataset.__init__(self, input_track)
 
-        self._input_label = input_label
+        self._indices = np.arange(Dataset.__len__(self), dtype=np.int64)
 
-        target_track.open()
+        is_target_track_closed = target_track.file.closed
+        if is_target_track_closed:
+            target_track.open()
         location_first, _ = target_track[0].location
         location_last, size_last = target_track[-1].location
         target_track.file.seek(location_first)
         buffer = target_track.file.read(location_last + size_last - location_first)
+        if is_target_track_closed:
+            target_track.close()
 
         self._targets = np.full(len(self._track), -1, np.int64)
         self._targets[:len(target_track)] = np.frombuffer(buffer, np.dtype("<i8"))
 
+        self._input_label = input_label
+
+    def __len__(self):
+        return len(self._indices)
+
     def __getitem__(self, index: int):
-        item = Dataset.__getitem__(self, index)
-        return self._Item(input=item.input,
-                          input_label=self._input_label,
-                          target=(self.targets[index],))
+        item = Dataset.__getitem__(self, self._indices[index])
+        return ClassificationDataset._Item(input=item.input,
+                                           input_label=self._input_label,
+                                           aux=self._targets[index])
 
     def __add__(self, other):
         raise NotImplementedError()
@@ -130,8 +141,8 @@ class ClassificationDataset(Dataset):
         return self._targets
 
     @staticmethod
-    def _validate_args(*args):
-        archive, tracks, input_label = args
+    def _validate_source(*args):
+        archive, tracks = args
 
         if archive is not None:
             if any(not isinstance(t, str) for t in tracks):
@@ -150,7 +161,7 @@ class ClassificationDataset(Dataset):
             raise ValueError("tracks option must be a pair of Track when "
                              "archive is not specified.")
 
-        return archive, tracks, input_label
+        return archive, tracks
 
 
 class ImageNet(ClassificationDataset):
@@ -179,16 +190,13 @@ class ImageNet(ClassificationDataset):
                  tracks: _ClassTracksType = ("bzna_input", "bzna_target"),
                  input_label: str = "bzna_thumb"):
         try:
-            archive, split, tracks, input_label = \
-                ImageNet._validate_args(None, split, root, input_label)
+            archive, split, tracks = \
+                ImageNet._validate_source(None, split, root)
         except (TypeError, ValueError):
-            archive, split, tracks, input_label = \
-                ImageNet._validate_args(root, split, tracks, input_label)
+            archive, split, tracks = \
+                ImageNet._validate_source(root, split, tracks)
 
         ClassificationDataset.__init__(self, archive, tracks, input_label)
-
-        self._indices = np.array(range(ClassificationDataset.__len__(self)),
-                                 np.int64)
 
         if split == "test":
             self._indices = self._indices[-self.LEN_TEST:]
@@ -204,21 +212,12 @@ class ImageNet(ClassificationDataset):
             self._indices = self._indices[len_train:-self.LEN_TEST]
             self._targets = self._targets[len_train:-self.LEN_TEST]
 
-    def __getitem__(self, index: int):
-        item = Dataset.__getitem__(self, self._indices[index])
-        return ImageNet._Item(input=item.input,
-                              input_label=self._input_label,
-                              target=(self._targets[index],))
-
-    def __len__(self):
-        return len(self._indices)
-
     def __add__(self, other):
         raise NotImplementedError()
 
     @staticmethod
-    def _validate_args(*args):
-        root, split, tracks, input_label = args
+    def _validate_source(*args):
+        root, split, tracks = args
 
         archive = None
 
@@ -254,4 +253,4 @@ class ImageNet(ClassificationDataset):
         if split not in {"test", "train", "val", None}:
             raise ValueError("split option must be one of test, train, val")
 
-        return archive, split, tracks, input_label
+        return archive, split, tracks

--- a/src/benzina/torch/operations.py
+++ b/src/benzina/torch/operations.py
@@ -464,8 +464,7 @@ class CenterResizedCrop     (SimilarityTransform):
             (default: ``+1.0``)
         keep_ratio (bool, optional): match the smaller edge to the
             corresponding output edge size, keeping the aspect ratio after
-            resize. Has no effect if :attr:`resize` is ``False``.
-            (default: ``False``)
+            resize. (default: ``False``)
     """
     def __init__(self,
                  scale=+1.0,

--- a/src/benzina/utils/__init__.py
+++ b/src/benzina/utils/__init__.py
@@ -1,3 +1,4 @@
 from .     import file
 from .     import mp4
 from .file import File, Track
+from .psnrhma import psnrhma_color

--- a/src/benzina/utils/file.py
+++ b/src/benzina/utils/file.py
@@ -6,66 +6,113 @@ from benzina.utils.mp4 import get_chunk_offset_at, get_name_at, \
     get_sample_size_at, get_shape_at, find_headers_at, \
     find_sample_table_at, find_video_configuration_at
 
+FileDesc = namedtuple("FileDesc", ["name", "mode"])
 Trak = namedtuple("Trak", ["label", "shape", "stbl_pos"])
 
 
-class File:
+class FileReadMixin:
+    def __init__(self, disk_file=None, *_args, **_kwargs):
+        self._file = disk_file
+
+    @property
+    def closed(self):
+        return self._file is None or self._file.closed
+
+    def seek(self, offset):
+        self._file.seek(offset)
+
+    def read(self, size):
+        return self._file.read(size)
+
+
+class FileProxy(FileReadMixin):
+    """ When closed, this proxy can be serialized without problems.
+    """
+    def __init__(self, disk_file, mode="rb"):
+        super().__init__(None, mode=mode)
+        self._name = None
+        self._mode = mode
+
+        if isinstance(disk_file, str):
+            self._name = disk_file
+        else:
+            self._name = disk_file.name
+            self._file = disk_file
+
+    def __enter__(self):
+        self.open()
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def mode(self):
+        return self._mode
+
+    def open(self):
+        if self.closed:
+            self._file = open(self._name, mode=self._mode)
+
+    def close(self):
+        if not self.closed:
+            self._file.close()
+            self._file = None
+
+
+class File(FileReadMixin):
     def __init__(self, disk_file, offset=0):
-        self._path = None
-        self._disk_file = None
+        super().__init__(disk_file, offset=offset)
+        self._owner = False
         self._offset = offset
         self._traks = None
 
         # If disk_file is a path, ownership of the disk file will be held by
         # this instance
         if isinstance(disk_file, str):
-            self._path = disk_file
-        else:
-            self._disk_file = disk_file
+            self._owner = True
+        if not isinstance(self._file, FileProxy):
+            self._file = FileProxy(disk_file, mode="rb")
+        if not self.closed:
             self._parse()
 
     def __enter__(self):
         # If self._path is set, ownership of the disk file is held by this
         # instance and it will be opened here
-        if self._path:
+        if self._owner:
             self.open()
         return self
 
     def __exit__(self, type, value, traceback):
         # If self._path is set, ownership of the disk file is held by this
         # instance and the file should be closed here
-        if self._path:
+        if self._owner:
             self.close()
 
     @property
-    def path(self):
-        return self._path
+    def name(self):
+        return self._file.name
 
     @property
     def offset(self):
         return self._offset
 
     def open(self):
-        if not self._disk_file or self._disk_file.closed:
-            self._disk_file = open(self._path, "rb")
+        self._file.open()
         if self._traks is None:
             self._parse()
 
     def close(self):
-        if self._disk_file and not self._disk_file.closed:
-            self._disk_file.close()
-            self._disk_file = None
-
-    def seek(self, offset):
-        self._disk_file.seek(offset)
-
-    def read(self, size):
-        return self._disk_file.read(size)
+        self._file.close()
 
     def trak(self, label):
         if self._traks is None:
             raise RuntimeError("File [{}] is missing a moov box"
-                               .format(self._disk_file.name if self._disk_file else self._path))
+                               .format(self._file.name))
 
         if isinstance(label, str):
             label = label.encode("utf-8")
@@ -76,24 +123,24 @@ class File:
         return self._traks.get(label, None)
 
     def subfile(self, offset):
-        return File(self._disk_file, offset=offset)
+        return File(self._file, offset=offset)
 
     def _parse(self):
         self._traks = {}
 
         moov_pos, box_size, _, header_size = \
-            next(find_headers_at(self._disk_file, {b"moov"}, self._offset))
-        self._disk_file.seek(moov_pos)
+            next(find_headers_at(self._file, {b"moov"}, self._offset))
+        self._file.seek(moov_pos)
         for trak_pos, _, _, _ in \
-            find_headers_at(self._disk_file, {b"trak"},
+            find_headers_at(self._file, {b"trak"},
                             moov_pos + header_size, box_size - header_size):
-            trak_label = get_name_at(self._disk_file, trak_pos)
+            trak_label = get_name_at(self._file, trak_pos)
 
             if trak_label[-1] == 0:
                 trak_label = trak_label[:-1]
 
-            trak_shape = get_shape_at(self._disk_file, trak_pos)
-            trak_stbl_pos, _, _, _ = find_sample_table_at(self._disk_file, trak_pos)
+            trak_shape = get_shape_at(self._file, trak_pos)
+            trak_stbl_pos, _, _, _ = find_sample_table_at(self._file, trak_pos)
 
             self._traks[trak_label] = Trak(trak_label,
                                            trak_shape,
@@ -101,7 +148,7 @@ class File:
 
 
 class Track:
-    def __init__(self, file, label):
+    def __init__(self, f, label):
         self._file_path = None
         self._file = None
         self._label = label
@@ -114,17 +161,21 @@ class Track:
         self._sz = np.empty(0, np.uint32)
 
         # If file is a path, ownership of the file will be held by this instance
-        if isinstance(file, str):
-            self._file_path = file
+        if isinstance(f, str):
+            self._file_path = f
+            self._file = File(self._file_path)
         else:
-            self._file = file
-            self._parse()
+            self._file = f
+            if not self._file.closed:
+                self._parse()
 
     def __len__(self):
         return self._len
 
     def __getitem__(self, index):
-        if index >= len(self):
+        if isinstance(index, slice):
+            return [Sample(self, i) for i in range(*index.indices(len(self)))]
+        elif index >= len(self):
             raise IndexError
         return Sample(self, index)
 
@@ -145,16 +196,12 @@ class Track:
             self.close()
 
     def open(self):
-        if not self._file:
-            self._file = File(self._file_path)
         self._file.open()
         if self._trak is None:
             self._parse()
 
     def close(self):
-        if self._file:
-            self._file.close()
-            self._file = None
+        self._file.close()
 
     @property
     def file(self):
@@ -172,6 +219,7 @@ class Track:
         return int(self._file.offset + self._co[index]), int(self._sz[index])
 
     def sample_bytes(self, index):
+        self.open()
         offset, size = self.sample_location(index)
         self._file.seek(offset)
         return self._file.read(size)
@@ -191,26 +239,23 @@ class Track:
         return pos + header_size, box_size - header_size
 
     def _parse(self):
-        self._trak = self._file.trak(self._label)
+        trak = self._file.trak(self._label)
 
         self._co, self._co_buffer = \
-            get_chunk_offset_at(self._file, self._trak.stbl_pos)
-
+            get_chunk_offset_at(self._file, trak.stbl_pos)
         self._sz, self._sz_buffer = \
-            get_sample_size_at(self._file, self._trak.stbl_pos)
+            get_sample_size_at(self._file, trak.stbl_pos)
 
-        if self._sz_buffer is None:
-            self._sz: int
-            self._sz = np.full(len(self._co), self._sz, np.uint32)
+        self._co, self._sz =  np.broadcast_arrays(self._co, self._sz)
 
         self._len = len(self._co)
+        self._trak = trak
 
 
 class Sample:
     def __init__(self, track, index):
         self._track = track
         self._index = index
-        pass
 
     def __bytes__(self):
         return self._track.sample_bytes(self._index)

--- a/src/benzina/utils/mp4.py
+++ b/src/benzina/utils/mp4.py
@@ -141,12 +141,11 @@ def get_sample_size_at(file, stbl_pos=None):
     stsz_buf = file.read(box_size)
     sample_size = int.from_bytes(stsz_buf[header_size:header_size + 4], "big")
     if sample_size > 0:
-        sz_buf = None
-        sz = sample_size
+        sz_buf = stsz_buf[header_size:header_size + 4]
     else:
         sz_buf = stsz_buf[header_size +
                           4 +   # sample_size: uint32
                           4:]   # sample_count: uint32
-        sz = np.frombuffer(sz_buf, np.dtype(">u4"))
+    sz = np.frombuffer(sz_buf, np.dtype(">u4"))
 
     return sz, sz_buf

--- a/src/benzina/utils/psnrhma.py
+++ b/src/benzina/utils/psnrhma.py
@@ -2,9 +2,18 @@
 # -*- coding: utf-8 -*-
 
 # Imports
-import cv2           as cv
-import numpy         as np
-import scipy.fftpack
+import importlib.util
+
+import numpy as np
+
+cv2_spec = importlib.util.find_spec("cv2")
+is_cv2_installed = cv2_spec is not None
+if is_cv2_installed:
+    import cv2 as cv
+scipy_spec = importlib.util.find_spec("scipy")
+is_scipy_installed = scipy_spec is not None
+if is_scipy_installed:
+    import scipy.fftpack
 
 
 #


### PR DESCRIPTION
As files can't be serialized, they need to be open after the serialization of the objects in a multiprocesses environment.

Supersedes #29